### PR TITLE
fix: add missing semicolons in message classes

### DIFF
--- a/Volt/src/main/java/dev/kingssack/volt/messages/MecanumCommandMessage.java
+++ b/Volt/src/main/java/dev/kingssack/volt/messages/MecanumCommandMessage.java
@@ -1,4 +1,4 @@
-package dev.kingssack.volt.messages
+package dev.kingssack.volt.messages;
 
 public final class MecanumCommandMessage {
     public long timestamp;

--- a/Volt/src/main/java/dev/kingssack/volt/messages/MecanumLocalizerInputsMessage.java
+++ b/Volt/src/main/java/dev/kingssack/volt/messages/MecanumLocalizerInputsMessage.java
@@ -1,4 +1,4 @@
-package dev.kingssack.volt.messages
+package dev.kingssack.volt.messages;
 
 import com.acmerobotics.roadrunner.ftc.PositionVelocityPair;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;


### PR DESCRIPTION
Add missing semicolons to the package declarations in 
MecanumCommandMessage.java and MecanumLocalizerInputsMessage.java. 
This change ensures proper syntax and adheres to Java coding standards.