### PR TITLE
Separate Drivetrains from Robots

### DIFF
--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/Drivetrain.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/Drivetrain.kt
@@ -1,0 +1,7 @@
+package dev.kingssack.volt.drivetrain
+
+import org.firstinspires.ftc.robotcore.external.Telemetry
+
+abstract class Drivetrain {
+    abstract fun update(telemetry: Telemetry)
+}

--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/SimpleMecanumDriveWithPP.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/SimpleMecanumDriveWithPP.kt
@@ -1,0 +1,62 @@
+package dev.kingssack.volt.drivetrain
+
+import com.acmerobotics.roadrunner.Action
+import com.acmerobotics.roadrunner.PoseVelocity2d
+import com.pedropathing.follower.Follower
+import com.pedropathing.follower.FollowerConstants
+import com.pedropathing.ftc.FollowerBuilder
+import com.pedropathing.ftc.drivetrains.MecanumConstants
+import com.pedropathing.ftc.localization.constants.DriveEncoderConstants
+import com.pedropathing.geometry.Pose
+import com.pedropathing.paths.PathChain
+import com.pedropathing.paths.PathConstraints
+import com.qualcomm.robotcore.hardware.HardwareMap
+import org.firstinspires.ftc.robotcore.external.Telemetry
+
+class SimpleMecanumDriveWithPP(
+    hardwareMap: HardwareMap,
+    followerConstants: FollowerConstants,
+    localizerConstants: DriveEncoderConstants,
+    pathConstraints: PathConstraints,
+    driveConstants: MecanumConstants,
+    var pose: Pose = Pose(),
+) : Drivetrain() {
+    private val follower: Follower =
+        FollowerBuilder(followerConstants, hardwareMap)
+            .driveEncoderLocalizer(localizerConstants)
+            .pathConstraints(pathConstraints)
+            .mecanumDrivetrain(driveConstants)
+            .build()
+
+    init {
+        follower.setStartingPose(pose)
+        follower.update()
+    }
+
+    fun startTeleOpDrive() {
+        follower.startTeleOpDrive()
+    }
+
+    fun setDrivePowers(powers: PoseVelocity2d) {
+        follower.setTeleOpDrive(powers.linearVel.x, powers.linearVel.y, powers.angVel)
+    }
+
+    fun pathTo(pathChain: PathChain): Action = Action {
+        if (!follower.isBusy) follower.followPath(pathChain)
+
+        follower.update()
+        val finished = !follower.isBusy
+
+        finished
+    }
+
+    override fun update(telemetry: Telemetry) {
+        follower.update()
+
+        telemetry.addLine("DRIVETRAIN-->")
+        telemetry.addData("x", follower.pose.x)
+        telemetry.addData("y", follower.pose.y)
+        telemetry.addData("heading", follower.pose.heading)
+        telemetry.addLine()
+    }
+}

--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/SimpleMecanumDriveWithRR.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/SimpleMecanumDriveWithRR.kt
@@ -1,32 +1,65 @@
-package dev.kingssack.volt.robot
+package dev.kingssack.volt.drivetrain
 
 import com.acmerobotics.dashboard.canvas.Canvas
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket
-import com.acmerobotics.roadrunner.*
-import com.acmerobotics.roadrunner.ftc.*
+import com.acmerobotics.roadrunner.AccelConstraint
+import com.acmerobotics.roadrunner.Action
+import com.acmerobotics.roadrunner.AngularVelConstraint
+import com.acmerobotics.roadrunner.DualNum
+import com.acmerobotics.roadrunner.HolonomicController
+import com.acmerobotics.roadrunner.MecanumKinematics
+import com.acmerobotics.roadrunner.MinVelConstraint
+import com.acmerobotics.roadrunner.MotorFeedforward
+import com.acmerobotics.roadrunner.Pose2d
+import com.acmerobotics.roadrunner.PoseVelocity2d
+import com.acmerobotics.roadrunner.PoseVelocity2dDual
+import com.acmerobotics.roadrunner.ProfileAccelConstraint
+import com.acmerobotics.roadrunner.ProfileParams
+import com.acmerobotics.roadrunner.Rotation2d
+import com.acmerobotics.roadrunner.Time
+import com.acmerobotics.roadrunner.TimeTrajectory
+import com.acmerobotics.roadrunner.TimeTurn
+import com.acmerobotics.roadrunner.TrajectoryActionBuilder
+import com.acmerobotics.roadrunner.TrajectoryBuilderParams
+import com.acmerobotics.roadrunner.TurnConstraints
+import com.acmerobotics.roadrunner.Twist2d
+import com.acmerobotics.roadrunner.Twist2dDual
+import com.acmerobotics.roadrunner.Vector2d
+import com.acmerobotics.roadrunner.VelConstraint
+import com.acmerobotics.roadrunner.ftc.DownsampledWriter
+import com.acmerobotics.roadrunner.ftc.Encoder
+import com.acmerobotics.roadrunner.ftc.LazyHardwareMapImu
+import com.acmerobotics.roadrunner.ftc.OverflowEncoder
+import com.acmerobotics.roadrunner.ftc.RawEncoder
+import com.acmerobotics.roadrunner.ftc.throwIfModulesAreOutdated
+import com.acmerobotics.roadrunner.now
+import com.acmerobotics.roadrunner.range
 import com.qualcomm.hardware.lynx.LynxModule
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.LogoFacingDirection
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.UsbFacingDirection
-import com.qualcomm.robotcore.hardware.*
-import dev.kingssack.volt.util.*
-import java.util.*
+import com.qualcomm.robotcore.hardware.DcMotor
+import com.qualcomm.robotcore.hardware.DcMotorEx
+import com.qualcomm.robotcore.hardware.DcMotorSimple
+import com.qualcomm.robotcore.hardware.HardwareMap
+import com.qualcomm.robotcore.hardware.IMU
+import com.qualcomm.robotcore.hardware.VoltageSensor
+import dev.kingssack.volt.util.Drawing
+import dev.kingssack.volt.util.DriveCommandMessage
+import dev.kingssack.volt.util.Localizer
+import dev.kingssack.volt.util.MecanumCommandMessage
+import dev.kingssack.volt.util.PoseMessage
+import java.util.LinkedList
 import kotlin.math.ceil
 import kotlin.math.max
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
 
-/**
- * Represents a robot with attachments and a mecanum drivetrain.
- *
- * @param hardwareMap the hardware map
- * @param pose the initial pose of the robot
- */
-open class SimpleRobotWithMecanumDrive(
+class SimpleMecanumDriveWithRR(
     hardwareMap: HardwareMap,
-    var pose: Pose2d,
-    private val params: DriveParams = DriveParams()
-) : Robot() {
+    var pose: Pose2d = Pose2d(Vector2d(0.0, 0.0), 0.0),
+    private val params: DriveParams = DriveParams(),
+) : Drivetrain() {
     /**
      * Parameters for the robot's mecanum drive.
      *
@@ -69,13 +102,13 @@ open class SimpleRobotWithMecanumDrive(
         val headingGain: Double = 0.0,
         val axialVelGain: Double = 0.0,
         val lateralVelGain: Double = 0.0,
-        val headingVelGain: Double = 0.0
+        val headingVelGain: Double = 0.0,
     )
 
     private val kinematics: MecanumKinematics =
         MecanumKinematics(
             params.inPerTick * params.trackWidthTicks,
-            params.inPerTick / params.lateralInPerTick
+            params.inPerTick / params.lateralInPerTick,
         )
 
     private val defaultTurnConstraints: TurnConstraints =
@@ -84,7 +117,7 @@ open class SimpleRobotWithMecanumDrive(
         MinVelConstraint(
             listOf(
                 kinematics.WheelVelConstraint(params.maxWheelVel),
-                AngularVelConstraint(params.maxAngVel)
+                AngularVelConstraint(params.maxAngVel),
             )
         )
     private val defaultAccelConstraint: AccelConstraint =
@@ -102,7 +135,7 @@ open class SimpleRobotWithMecanumDrive(
         LazyHardwareMapImu(
             hardwareMap,
             "imu",
-            RevHubOrientationOnRobot(params.logoFacingDirection, params.usbFacingDirection)
+            RevHubOrientationOnRobot(params.logoFacingDirection, params.usbFacingDirection),
         )
 
     val localizer = DriveLocalizer(pose)
@@ -136,16 +169,16 @@ open class SimpleRobotWithMecanumDrive(
 
             val angles = imu.robotYawPitchRollAngles
 
-            FlightRecorder.write(
-                "MECANUM_LOCALIZER_INPUTS",
-                MecanumLocalizerInputsMessage(
-                    leftFrontPosVel,
-                    leftBackPosVel,
-                    rightBackPosVel,
-                    rightFrontPosVel,
-                    angles
-                )
-            )
+            //            FlightRecorder.write(
+            //                "MECANUM_LOCALIZER_INPUTS",
+            //                MecanumLocalizerInputsMessage(
+            //                    leftFrontPosVel,
+            //                    leftBackPosVel,
+            //                    rightBackPosVel,
+            //                    rightFrontPosVel,
+            //                    angles
+            //                )
+            //            )
 
             val heading = Rotation2d.exp(angles.getYaw(AngleUnit.RADIANS))
 
@@ -167,41 +200,33 @@ open class SimpleRobotWithMecanumDrive(
                 kinematics.forward(
                     MecanumKinematics.WheelIncrements(
                         DualNum<Time>(
-                            doubleArrayOf(
-                                (leftFrontPosVel.position -
-                                        lastLeftFrontPos)
-                                    .toDouble(),
-                                leftFrontPosVel.velocity!!.toDouble(),
+                                doubleArrayOf(
+                                    (leftFrontPosVel.position - lastLeftFrontPos).toDouble(),
+                                    leftFrontPosVel.velocity!!.toDouble(),
+                                )
                             )
-                        )
                             .times(params.inPerTick),
                         DualNum<Time>(
-                            doubleArrayOf(
-                                (leftBackPosVel.position -
-                                        lastLeftBackPos)
-                                    .toDouble(),
-                                leftBackPosVel.velocity!!.toDouble(),
+                                doubleArrayOf(
+                                    (leftBackPosVel.position - lastLeftBackPos).toDouble(),
+                                    leftBackPosVel.velocity!!.toDouble(),
+                                )
                             )
-                        )
                             .times(params.inPerTick),
                         DualNum<Time>(
-                            doubleArrayOf(
-                                (rightBackPosVel.position -
-                                        lastRightBackPos)
-                                    .toDouble(),
-                                rightBackPosVel.velocity!!.toDouble(),
+                                doubleArrayOf(
+                                    (rightBackPosVel.position - lastRightBackPos).toDouble(),
+                                    rightBackPosVel.velocity!!.toDouble(),
+                                )
                             )
-                        )
                             .times(params.inPerTick),
                         DualNum<Time>(
-                            doubleArrayOf(
-                                (rightFrontPosVel.position -
-                                        lastRightFrontPos)
-                                    .toDouble(),
-                                rightFrontPosVel.velocity!!.toDouble(),
+                                doubleArrayOf(
+                                    (rightFrontPosVel.position - lastRightFrontPos).toDouble(),
+                                    rightFrontPosVel.velocity!!.toDouble(),
+                                )
                             )
-                        )
-                            .times(params.inPerTick)
+                            .times(params.inPerTick),
                     )
                 )
 
@@ -216,6 +241,11 @@ open class SimpleRobotWithMecanumDrive(
 
             return twist.velocity().value()
         }
+
+        init {
+            rightFront.direction = DcMotorSimple.Direction.REVERSE
+            rightBack.direction = DcMotorSimple.Direction.REVERSE
+        }
     }
 
     init {
@@ -226,13 +256,15 @@ open class SimpleRobotWithMecanumDrive(
         }
 
         driveMotors.forEach { it.zeroPowerBehavior = DcMotor.ZeroPowerBehavior.BRAKE }
+
+        rightFront.direction = DcMotorSimple.Direction.REVERSE
+        rightBack.direction = DcMotorSimple.Direction.REVERSE
     }
 
     /**
      * Set the drive powers.
      *
      * @param powers the drive powers
-     *
      * @see PoseVelocity2d
      */
     fun setDrivePowers(powers: PoseVelocity2d) {
@@ -260,8 +292,7 @@ open class SimpleRobotWithMecanumDrive(
                 range(
                     0.0,
                     timeTrajectory.path.length(),
-                    max(2.0, ceil(timeTrajectory.path.length() / 2).toInt().toDouble())
-                        .toInt()
+                    max(2.0, ceil(timeTrajectory.path.length() / 2).toInt().toDouble()).toInt(),
                 )
             xPoints = DoubleArray(disps.size)
             yPoints = DoubleArray(disps.size)
@@ -297,13 +328,13 @@ open class SimpleRobotWithMecanumDrive(
 
             val command =
                 HolonomicController(
-                    params.axialGain,
-                    params.lateralGain,
-                    params.headingGain,
-                    params.axialVelGain,
-                    params.lateralVelGain,
-                    params.headingVelGain
-                )
+                        params.axialGain,
+                        params.lateralGain,
+                        params.headingGain,
+                        params.axialVelGain,
+                        params.lateralVelGain,
+                        params.headingVelGain,
+                    )
                     .compute(txWorldTarget, localizer.pose, robotVelRobot)
             driveCommandWriter.write(DriveCommandMessage(command))
 
@@ -314,7 +345,7 @@ open class SimpleRobotWithMecanumDrive(
                 MotorFeedforward(
                     params.kS,
                     params.kV / params.inPerTick,
-                    params.kA / params.inPerTick
+                    params.kA / params.inPerTick,
                 )
             val leftFrontPower = feedforward.compute(wheelVels.leftFront) / voltage
             val leftBackPower = feedforward.compute(wheelVels.leftBack) / voltage
@@ -326,7 +357,7 @@ open class SimpleRobotWithMecanumDrive(
                     leftFrontPower,
                     leftBackPower,
                     rightBackPower,
-                    rightFrontPower
+                    rightFrontPower,
                 )
             )
 
@@ -395,13 +426,13 @@ open class SimpleRobotWithMecanumDrive(
 
             val command =
                 HolonomicController(
-                    params.axialGain,
-                    params.lateralGain,
-                    params.headingGain,
-                    params.axialVelGain,
-                    params.lateralVelGain,
-                    params.headingVelGain
-                )
+                        params.axialGain,
+                        params.lateralGain,
+                        params.headingGain,
+                        params.axialVelGain,
+                        params.lateralVelGain,
+                        params.headingVelGain,
+                    )
                     .compute(txWorldTarget, localizer.pose, robotVelRobot)
             driveCommandWriter.write(DriveCommandMessage(command))
 
@@ -411,7 +442,7 @@ open class SimpleRobotWithMecanumDrive(
                 MotorFeedforward(
                     params.kS,
                     params.kV / params.inPerTick,
-                    params.kA / params.inPerTick
+                    params.kA / params.inPerTick,
                 )
             val leftFrontPower = feedforward.compute(wheelVels.leftFront) / voltage
             val leftBackPower = feedforward.compute(wheelVels.leftBack) / voltage
@@ -423,7 +454,7 @@ open class SimpleRobotWithMecanumDrive(
                     leftFrontPower,
                     leftBackPower,
                     rightBackPower,
-                    rightFrontPower
+                    rightFrontPower,
                 )
             )
 
@@ -461,7 +492,7 @@ open class SimpleRobotWithMecanumDrive(
             poseHistory.removeFirst()
         }
 
-        estimatedPoseWriter.write(PoseMessage(localizer.pose))
+        //        estimatedPoseWriter.write(PoseMessage(localizer.pose))
 
         return vel
     }
@@ -498,52 +529,67 @@ open class SimpleRobotWithMecanumDrive(
             0.0,
             defaultTurnConstraints,
             defaultVelConstraint,
-            defaultAccelConstraint
+            defaultAccelConstraint,
         )
     }
 
     /**
      * Strafe to a [target] vector.
+     *
      * @return the action
      */
-    fun strafeTo(target: Vector2d): Action {
-        return driveActionBuilder(localizer.pose).strafeTo(target).build()
-    }
+    fun strafeTo(target: Vector2d): Action =
+        driveActionBuilder(localizer.pose).strafeTo(target).build()
 
     /**
      * Strafe to a [target] vector with a linear [heading].
+     *
      * @return the action
      */
-    fun strafeToLinearHeading(target: Vector2d, heading: Double): Action {
-        return driveActionBuilder(localizer.pose).strafeToLinearHeading(target, heading).build()
-    }
+    fun strafeToLinearHeading(target: Vector2d, heading: Double): Action =
+        driveActionBuilder(localizer.pose).strafeToLinearHeading(target, heading).build()
 
     /**
      * Turn to a [target] angle in radians.
+     *
      * @return the action
      */
-    fun turnTo(target: Double): Action {
-        return driveActionBuilder(localizer.pose).turnTo(target).build()
-    }
+    fun turnTo(target: Double): Action = driveActionBuilder(localizer.pose).turnTo(target).build()
 
     /**
      * Turn a certain number of [radians].
+     *
      * @return the action
      */
-    fun turn(radians: Double): Action {
-        return driveActionBuilder(localizer.pose).turn(radians).build()
-    }
+    fun turn(radians: Double): Action = driveActionBuilder(localizer.pose).turn(radians).build()
 
     /**
      * Wait for a certain number of [seconds].
+     *
      * @return the action
      */
-    fun wait(seconds: Double): Action {
-        return driveActionBuilder(localizer.pose).waitSeconds(seconds).build()
+    fun wait(seconds: Double): Action =
+        driveActionBuilder(localizer.pose).waitSeconds(seconds).build()
+
+    /**
+     * Build a trajectory action.
+     *
+     * @return the built action
+     */
+    fun trajectory(
+        beginPose: Pose2d = localizer.pose,
+        block: TrajectoryActionBuilder.() -> TrajectoryActionBuilder,
+    ): Action {
+        return driveActionBuilder(beginPose).block().build()
     }
 
     override fun update(telemetry: Telemetry) {
         updatePoseEstimate()
-        super.update(telemetry)
+
+        telemetry.addLine("DRIVETRAIN-->")
+        telemetry.addData("x", localizer.pose.position.x)
+        telemetry.addData("y", localizer.pose.position.y)
+        telemetry.addData("heading (deg)", Math.toDegrees(localizer.pose.heading.toDouble()))
+        telemetry.addLine()
     }
 }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/autonomous/AutonomousMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/autonomous/AutonomousMode.kt
@@ -22,8 +22,14 @@ abstract class AutonomousMode<R : Robot>(private val robotFactory: (HardwareMap)
     private val dash: FtcDashboard? = FtcDashboard.getInstance()
     private val canvas = Canvas()
 
+    /** Optional initialization code for the autonomous mode. */
+    open fun initialize() {
+        // Default implementation does nothing
+    }
+
     override fun runOpMode() {
         robot = robotFactory(hardwareMap)
+        initialize()
         waitForStart()
         sequence()
     }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/ManualMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/ManualMode.kt
@@ -122,9 +122,15 @@ abstract class ManualMode<R : Robot>(
         }
     }
 
+    /** Optional initialization code can be added here. */
+    open fun initialize() {
+        // Default implementation does nothing
+    }
+
     override fun runOpMode() {
         initializeInputMappings()
         robot = robotFactory(hardwareMap)
+        initialize()
         waitForStart()
         while (opModeIsActive()) {
             tick()

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/SimpleManualModeWithSpeedModes.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/SimpleManualModeWithSpeedModes.kt
@@ -105,6 +105,7 @@ abstract class SimpleManualModeWithSpeedModes<R : Robot>(
 
     override fun tick() {
         telemetry.addData("Speed Mode", currentSpeedMode)
+        telemetry.addLine()
         super.tick()
     }
 }


### PR DESCRIPTION
This pull request refactors the drivetrain architecture by introducing a new `Drivetrain` abstraction and reorganizing the mecanum drive implementations. It separates different drive approaches into their own classes, improves code clarity, and standardizes telemetry output for drivetrain classes. The changes also include minor code style improvements and the addition of utility methods for trajectory building.

**Drivetrain architecture and code organization:**

* Introduced a new abstract `Drivetrain` class in `Drivetrain.kt` to serve as a base for all drivetrain implementations.
* Moved and renamed the mecanum drive class based on Road Runner from `SimpleRobotWithMecanumDrive` to `SimpleMecanumDriveWithRR`, placing it in the `drivetrain` package for clearer organization.
* Added a new `SimpleMecanumDriveWithPP` class implementing the PathPlanner-based mecanum drive, also inheriting from the new `Drivetrain` base class.

**API improvements and utility methods:**

* Refactored trajectory and action-building methods in `SimpleMecanumDriveWithRR` to use concise expression bodies and added a new `trajectory` builder method for greater flexibility.

**Telemetry and code style:**

* Standardized the `update` method in both drivetrain classes to output pose telemetry in a consistent format. [[1]](diffhunk://#diff-dd346dd20f1dddd59fc4076cef88bf58a16e8377312dbb6b5ed0867123e194faR1-R62) [[2]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL501-R593)
* Applied code style improvements throughout `SimpleMecanumDriveWithRR`, such as adding trailing commas, simplifying expressions, and commenting out unused or deprecated code sections. [[1]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL72-R111) [[2]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL87-R120) [[3]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL105-R138) [[4]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL139-R181) [[5]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL171-R229) [[6]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fR244-R248) [[7]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fR259-L235) [[8]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL263-R295) [[9]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL305-R336) [[10]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL317-R348) [[11]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL329-R360) [[12]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL403-R434) [[13]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL414-R445) [[14]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL426-R457) [[15]](diffhunk://#diff-b86811df6ccb2a65be62d47628f1eef5d5078a655c876d578ccc9f315089535fL464-R495)